### PR TITLE
(CT-146) Implemented the delete-token-file subcommand

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/puppetlabs/pe-cli
 go 1.15
 
 require (
+	github.com/puppetlabs/pe-sdk-go v0.0.0-20210216145142-42bae135496e
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/puppetlabs/pe-sdk-go v0.0.0-20210216145142-42bae135496e h1:mg7zsWq0T9x85SbyuAYz2EXKTrV9HjANXe55kEcT/6c=
+github.com/puppetlabs/pe-sdk-go v0.0.0-20210216145142-42bae135496e/go.mod h1:sjLpwwUMU3NrnAJ3DePxg5h0b4RsUD0GF8fEJhn1SXc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/puppet-access/subcommands/delete-token-file.go
+++ b/puppet-access/subcommands/delete-token-file.go
@@ -1,9 +1,18 @@
 package main
 
 import (
+	"os"
+
+	"github.com/puppetlabs/pe-cli/log"
 	cmd "github.com/puppetlabs/pe-cli/puppet-access"
+
+	"github.com/puppetlabs/pe-sdk-go/token/filetoken"
+
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+var force bool
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete-token-file",
@@ -16,5 +25,12 @@ func init() {
 }
 
 func executeDeleteCommand(cmd *cobra.Command, args []string) {
-
+	//FIXME add --force flag
+	force := false
+	fileToken := filetoken.NewFileToken(viper.GetString("token-file"))
+	err := fileToken.Delete(force)
+	if err != nil {
+		log.Error(err.Error())
+		os.Exit(1)
+	}
 }

--- a/vendor/github.com/puppetlabs/pe-sdk-go/log/golog/golog.go
+++ b/vendor/github.com/puppetlabs/pe-sdk-go/log/golog/golog.go
@@ -1,0 +1,67 @@
+package golog
+
+import (
+	"fmt"
+	"io"
+	gologger "log"
+
+	"github.com/puppetlabs/pe-sdk-go/log/loginterface"
+	"github.com/puppetlabs/pe-sdk-go/log/loglevel"
+)
+
+type golog struct {
+	logLevel loglevel.LogLevel
+}
+
+//NewGolog constructs a golog instance
+func NewGolog() loginterface.Log {
+	return &golog{
+		logLevel: loglevel.Info,
+	}
+}
+
+func (l *golog) Trace(msg string) {
+	if l.logLevel <= loglevel.Trace {
+		gologger.Println(msg)
+	}
+}
+
+func (l *golog) Debug(msg string) {
+	if l.logLevel <= loglevel.Debug {
+		gologger.Println(msg)
+	}
+}
+
+func (l *golog) Info(msg string) {
+	if l.logLevel <= loglevel.Info {
+		gologger.Println(msg)
+	}
+}
+
+func (l *golog) Warn(msg string) {
+	if l.logLevel <= loglevel.Warn {
+		gologger.Println(msg)
+	}
+}
+
+func (l *golog) Error(msg string) {
+	if l.logLevel <= loglevel.Error {
+		gologger.Println(msg)
+	}
+}
+
+func (l *golog) SetOutput(w io.Writer) {
+	gologger.SetOutput(w)
+}
+
+func (l *golog) SetLogLevel(level string) error {
+	l.logLevel = loglevel.Enumify(level)
+	if l.logLevel == loglevel.Unknown {
+		return fmt.Errorf("Invalid log level provided: %s", level)
+	}
+	return nil
+}
+
+func (l *golog) GetLogLevel() loglevel.LogLevel {
+	return l.logLevel
+}

--- a/vendor/github.com/puppetlabs/pe-sdk-go/log/log.go
+++ b/vendor/github.com/puppetlabs/pe-sdk-go/log/log.go
@@ -1,0 +1,57 @@
+package log
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/puppetlabs/pe-sdk-go/log/golog"
+	"github.com/puppetlabs/pe-sdk-go/log/loginterface"
+	"github.com/puppetlabs/pe-sdk-go/log/loglevel"
+)
+
+var instance = golog.NewGolog()
+
+//SetInstance sets logger instance
+func SetInstance(log loginterface.Log) {
+	instance = log
+}
+
+//Trace logs a trace message
+func Trace(msg string) {
+	instance.Trace(fmt.Sprintf("TRACE - %s", msg))
+}
+
+//Debug logs a debug message
+func Debug(msg string) {
+	instance.Debug(fmt.Sprintf("DEBUG - %s", msg))
+}
+
+//Info logs an info message
+func Info(msg string) {
+	instance.Info(fmt.Sprintf("INFO - %s", msg))
+}
+
+//Warn logs a warning message
+func Warn(msg string) {
+	instance.Warn(fmt.Sprintf("WARN - %s", msg))
+}
+
+//Error logs an error message
+func Error(msg string) {
+	instance.Error(fmt.Sprintf("ERROR - %s", msg))
+}
+
+//SetLogLevel sets the log level
+func SetLogLevel(logLevel string) error {
+	return instance.SetLogLevel(logLevel)
+}
+
+//GetLogLevel gets the log level
+func GetLogLevel() loglevel.LogLevel {
+	return instance.GetLogLevel()
+}
+
+//setOutput sets log output
+func setOutput(w io.Writer) {
+	instance.SetOutput(w)
+}

--- a/vendor/github.com/puppetlabs/pe-sdk-go/log/loginterface/log.go
+++ b/vendor/github.com/puppetlabs/pe-sdk-go/log/loginterface/log.go
@@ -1,0 +1,19 @@
+package loginterface
+
+import (
+	"io"
+
+	"github.com/puppetlabs/pe-sdk-go/log/loglevel"
+)
+
+//Log interface to logging service
+type Log interface {
+	Trace(msg string)
+	Debug(msg string)
+	Info(msg string)
+	Warn(msg string)
+	Error(msg string)
+	SetOutput(w io.Writer)
+	SetLogLevel(logLevel string) error
+	GetLogLevel() loglevel.LogLevel
+}

--- a/vendor/github.com/puppetlabs/pe-sdk-go/log/loglevel/loglevel.go
+++ b/vendor/github.com/puppetlabs/pe-sdk-go/log/loglevel/loglevel.go
@@ -1,0 +1,36 @@
+package loglevel
+
+//LogLevel integer values
+type LogLevel int
+
+//Debug and all supported log levels
+const (
+	Trace LogLevel = iota
+	Debug
+	Info
+	Warn
+	Error
+	None
+	Unknown
+)
+
+// Enumify converts a log level passed as string to its corresponding enum value
+func Enumify(str string) (level LogLevel) {
+	switch str {
+	case "":
+		level = None
+	case "trace":
+		level = Trace
+	case "debug":
+		level = Debug
+	case "info":
+		level = Info
+	case "warn":
+		level = Warn
+	case "error":
+		level = Error
+	default:
+		level = Unknown
+	}
+	return
+}

--- a/vendor/github.com/puppetlabs/pe-sdk-go/token/filetoken/filetoken.go
+++ b/vendor/github.com/puppetlabs/pe-sdk-go/token/filetoken/filetoken.go
@@ -1,0 +1,117 @@
+package filetoken
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/puppetlabs/pe-sdk-go/log"
+	"github.com/puppetlabs/pe-sdk-go/token"
+)
+
+// fileToken struct
+type fileToken struct {
+	path string
+}
+
+// NewFileToken constructs a new filetoken
+func NewFileToken(path string) token.Token {
+	fileToken := fileToken{path: getPath(path)}
+	return &fileToken
+}
+
+// Read reads the token from a file and returns a valid token.
+// If the token is not valid an error will be returned
+func (ft *fileToken) Read() (string, error) {
+	return ft.readToken()
+}
+
+//DeleteFile deletes the token file
+//If the token is not valid, or file is a symlink an error will be returned
+func (ft *fileToken) Delete(force bool) error {
+	if force == true {
+		return ft.deleteFile()
+	}
+	_, err := ft.readToken()
+	if err != nil {
+		return err
+	}
+	return ft.deleteFile()
+}
+
+func (ft *fileToken) deleteFile() error {
+	file, err := os.Lstat(ft.path)
+	if err != nil {
+		return err
+	}
+	if file.Mode()&os.ModeSymlink == os.ModeSymlink {
+		return errors.New("Cannot delete token because it is a symbolic link instead of a token file:" + ft.path)
+	}
+	err = os.Remove(ft.path)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Token file deleted")
+	return nil
+}
+
+func getPath(path string) string {
+	if path == "" {
+		return defaultPath()
+	}
+	return path
+}
+
+func (ft *fileToken) readToken() (string, error) {
+	data, err := ioutil.ReadFile(ft.path)
+	if err != nil {
+		return "", err
+	}
+	token := strings.TrimRight(string(data), "\r\n")
+	valid := isValid(token)
+	if !valid {
+		return "", fmt.Errorf("Malformed token: token does not match expected formats")
+	}
+	return token, nil
+}
+
+func isValid(content string) bool {
+	// tokens can be of one of two flavors -- they can be jwt like, or new token like
+	// jwt tokens consist of three segments, dot separated, which each section being at
+	// least four characters from A-Za-z0-9_-
+	// new tokens consist only of characters A-Za-z0-9_-
+
+	jwtExpresion := `([A-Za-z0-9_-]{4,})\.([A-Za-z0-9_-]{4,})\.([A-Za-z0-9_-]{4,})`
+	tokenExpr := `^([A-Za-z0-9_-]+)$` //regexp.MatchString searches for any match, so we should specify that it should match the whole string with ^$
+
+	jwtMatched, _ := regexp.MatchString(jwtExpresion, content)
+	if jwtMatched {
+		fmt.Println("JWT")
+		log.Debug("Token is in JWT format")
+		return true
+	}
+
+	exprMatch, _ := regexp.MatchString(tokenExpr, content)
+	if exprMatch {
+		fmt.Println("valid")
+		log.Debug("Token format is valid")
+		return true
+	}
+	return false
+}
+
+//defaultPath returns token default path
+func defaultPath() string {
+	usr, err := user.Current()
+	if err != nil {
+		//FIXME log level
+		log.Debug(err.Error())
+		return ""
+	}
+	return filepath.Join(usr.HomeDir, ".puppetlabs", "token")
+}

--- a/vendor/github.com/puppetlabs/pe-sdk-go/token/token.go
+++ b/vendor/github.com/puppetlabs/pe-sdk-go/token/token.go
@@ -1,0 +1,7 @@
+package token
+
+//Token interface to read a token
+type Token interface {
+	Read() (string, error)
+	Delete(bool) error
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -23,6 +23,14 @@ github.com/mitchellh/mapstructure
 github.com/pelletier/go-toml
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
+# github.com/puppetlabs/pe-sdk-go v0.0.0-20210216145142-42bae135496e
+## explicit
+github.com/puppetlabs/pe-sdk-go/log
+github.com/puppetlabs/pe-sdk-go/log/golog
+github.com/puppetlabs/pe-sdk-go/log/loginterface
+github.com/puppetlabs/pe-sdk-go/log/loglevel
+github.com/puppetlabs/pe-sdk-go/token
+github.com/puppetlabs/pe-sdk-go/token/filetoken
 # github.com/spf13/afero v1.1.2
 github.com/spf13/afero
 github.com/spf13/afero/mem


### PR DESCRIPTION
This pull request aims to add the delete-token-file subcommand to puppet-access.
Depends on https://github.com/puppetlabs/pe-sdk-go/pull/3